### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,4 +1,6 @@
 name: Hugo site CI
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/grzanka/nz62www/security/code-scanning/2](https://github.com/grzanka/nz62www/security/code-scanning/2)

To fix the problem, we should explicitly set the `permissions` block at the top (root) level of the workflow file. This will apply the least privilege required to all jobs in the workflow. Since the workflow contains a deploy step that pushes to GitHub Pages (requiring write access to repository contents), the minimum required permissions are `contents: write`. Other steps, such as building the site or checking out code, do not require additional permissions. By setting `permissions: contents: write` at the top of the workflow, we make the necessary permission explicit and reduce excess access.

This change involves inserting a `permissions` block after the `name` and before the `on` key in the `.github/workflows/hugo.yml` file. No other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
